### PR TITLE
Fix divergent python version for tests issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ install: iasimage check
 
 check:
 	python tests/test_iasimage.py
+	./iasimage -V
 
 .PHONY: all check install
 

--- a/iasimage
+++ b/iasimage
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/tests/test_iasimage.py
+++ b/tests/test_iasimage.py
@@ -25,11 +25,11 @@ class MyTests(unittest.TestCase):
 				pass
 
 	def test_help(self):
-		cmd = ['python', IASIMAGE, '-h']
+		cmd = ['python3', IASIMAGE, '-h']
 		subprocess.check_call(cmd)
 
 	def test_version(self):
-		cmd = ['python', IASIMAGE, '-V']
+		cmd = ['python3', IASIMAGE, '-V']
 		subprocess.check_call(cmd)
 
 	def test_create_and_extract_then_compare(self):
@@ -39,11 +39,11 @@ class MyTests(unittest.TestCase):
 			bz_f.write(b'b' * 1024 * 1024 * 2)
 		with open('initrd.bin', 'wb') as initrd_f:
 			initrd_f.write(b'f' * 1024 * 1024 * 3)
-		cmd = ['python', IASIMAGE, 'create', '-o', 'output.bin', 
+		cmd = ['python3', IASIMAGE, 'create', '-o', 'output.bin', 
 		       '-i', '0x30000', 'cmdline.txt', 'bzImage.bin', 'initrd.bin']
 		subprocess.check_call(cmd)
 
-		cmd = ['python', IASIMAGE, 'extract', 'output.bin']
+		cmd = ['python3', IASIMAGE, 'extract', 'output.bin']
 		subprocess.check_call(cmd)
 
 		self.assertTrue(filecmp.cmp('cmdline.txt', os.path.join('extract', 'image_0.bin')))
@@ -55,7 +55,7 @@ class MyTests(unittest.TestCase):
 			cmd_f.write(b'c' * 128)
 		with open('bzImage.bin', 'wb') as bz_f:
 			bz_f.write(b'b' * 1024 * 1024 * 2)
-		cmd = ['python', IASIMAGE, 'create', '-o', 'output.bin', 
+		cmd = ['python3', IASIMAGE, 'create', '-o', 'output.bin', 
 		       '-i', '0x30000', 'cmdline.txt', 'bzImage.bin']
 		subprocess.check_call(cmd)
 
@@ -77,7 +77,7 @@ class MyTests(unittest.TestCase):
 		subprocess.check_call(cmd)
 
 		# Attach signature to output.bin
-		cmd = ['python', IASIMAGE, 'sign', '-o', 'output.signed.bin', '-s', 'output.sig',
+		cmd = ['python3', IASIMAGE, 'sign', '-o', 'output.signed.bin', '-s', 'output.sig',
 		       '-k', 'public_key.pem', 'output.bin']
 		subprocess.check_call(cmd)
 

--- a/tests/test_iasimage.py
+++ b/tests/test_iasimage.py
@@ -25,11 +25,11 @@ class MyTests(unittest.TestCase):
 				pass
 
 	def test_help(self):
-		cmd = ['python3', IASIMAGE, '-h']
+		cmd = ['python', IASIMAGE, '-h']
 		subprocess.check_call(cmd)
 
 	def test_version(self):
-		cmd = ['python3', IASIMAGE, '-V']
+		cmd = ['python', IASIMAGE, '-V']
 		subprocess.check_call(cmd)
 
 	def test_create_and_extract_then_compare(self):
@@ -39,11 +39,11 @@ class MyTests(unittest.TestCase):
 			bz_f.write(b'b' * 1024 * 1024 * 2)
 		with open('initrd.bin', 'wb') as initrd_f:
 			initrd_f.write(b'f' * 1024 * 1024 * 3)
-		cmd = ['python3', IASIMAGE, 'create', '-o', 'output.bin', 
+		cmd = ['python', IASIMAGE, 'create', '-o', 'output.bin', 
 		       '-i', '0x30000', 'cmdline.txt', 'bzImage.bin', 'initrd.bin']
 		subprocess.check_call(cmd)
 
-		cmd = ['python3', IASIMAGE, 'extract', 'output.bin']
+		cmd = ['python', IASIMAGE, 'extract', 'output.bin']
 		subprocess.check_call(cmd)
 
 		self.assertTrue(filecmp.cmp('cmdline.txt', os.path.join('extract', 'image_0.bin')))
@@ -55,7 +55,7 @@ class MyTests(unittest.TestCase):
 			cmd_f.write(b'c' * 128)
 		with open('bzImage.bin', 'wb') as bz_f:
 			bz_f.write(b'b' * 1024 * 1024 * 2)
-		cmd = ['python3', IASIMAGE, 'create', '-o', 'output.bin', 
+		cmd = ['python', IASIMAGE, 'create', '-o', 'output.bin', 
 		       '-i', '0x30000', 'cmdline.txt', 'bzImage.bin']
 		subprocess.check_call(cmd)
 
@@ -77,7 +77,7 @@ class MyTests(unittest.TestCase):
 		subprocess.check_call(cmd)
 
 		# Attach signature to output.bin
-		cmd = ['python3', IASIMAGE, 'sign', '-o', 'output.signed.bin', '-s', 'output.sig',
+		cmd = ['python', IASIMAGE, 'sign', '-o', 'output.signed.bin', '-s', 'output.sig',
 		       '-k', 'public_key.pem', 'output.bin']
 		subprocess.check_call(cmd)
 


### PR DESCRIPTION
The first line of ```iasimage``` (```#!/usr/bin/env python3```) indicates that the script
will use by default the ```python3``` interpreter. That is, when the user call it
directly, after it has been installed in the ```PATH```, e.g.
```
$ iasimage create [...]
```
it will be interpreted using ```python3```.

However, the tests performed here (```test_iasimage.py```) call iasimage explicitely
using the ```python2.7``` interpreter [1].

This leads to confusion because on a system where ```python2.7``` is installed and
with all the libraries up-to-date, make install will successfully perform the
tests and install ```iasimage```, but its usage now depends on whether ```python3``` is
installed and/or the dependencies to cryptography, etc. are met (definitely not
what the user expected after a successful install and test). For example, on
a system with no ```python3``` installed or with missing ```python3``` dependencies, the
above call will fail even though ```iasimage``` was validated and installed.

Since ```iasimage``` is interpreted by default using ```python3```, the tests have been
modified to also test the script using the same version of python (so it makes
sense for the user). If the user wants to call the script with a different
version of python, but explicitly, that is a different story.

[1] https://askubuntu.com/a/475815/37468